### PR TITLE
Add baseline comparison for bicubic super resolution

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,5 @@ repos:
       # Run Ruff lint with --fix only on pre-push
       - id: ruff
         args: [--fix]
-        stages: [push]
-
       # Run Ruff formatter on pre-commit
       - id: ruff-format
-        stages: [push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.8
+    hooks:
+      # Run Ruff lint with --fix only on pre-push
+      - id: ruff
+        args: [--fix]
+        stages: [push]
+
+      # Run Ruff formatter on pre-commit
+      - id: ruff-format
+        stages: [push]

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - tqdm
   - matplotlib
   - polars
+  - pre-commit
   - pip
   - pip:
       - torch

--- a/script.sh
+++ b/script.sh
@@ -17,5 +17,5 @@ source activate vae-rs
 
 export SCRATCH="/scratch/disc/e.bardet/"
 
-python train.py --patch_size 64 --batch_size 32
+python train.py --patch_size 64 --batch_size 32 --pre_epochs 0
 

--- a/script.sh
+++ b/script.sh
@@ -17,5 +17,5 @@ source activate vae-rs
 
 export SCRATCH="/scratch/disc/e.bardet/"
 
-python train.py --patch_size 64 --batch_size 32 --pre_epochs 0
+python train.py --patch_size 64 --batch_size 128 --pre_epochs 100
 

--- a/train.py
+++ b/train.py
@@ -183,7 +183,9 @@ def train(
 
         writer.add_images(
             "Conditional Generation/HR_Interpolation",
-            F.interpolate(y.view(-1, c, h, w)[:, bands, :, :],scale_factor=2,mode="bicubic"),
+            F.interpolate(
+                y.view(-1, c, h, w)[:, bands, :, :], scale_factor=2, mode="bicubic"
+            ),
             global_step=epoch,
             dataformats="NCHW",
         )

--- a/train.py
+++ b/train.py
@@ -10,7 +10,6 @@ from tqdm import tqdm
 from dataset import init_dataloader
 from loss import cond_loss
 from model import Cond_SRVAE
-from utils import normalize_image
 
 
 def train(
@@ -147,14 +146,14 @@ def train(
 
         writer.add_images(
             "Reconstruction/LR_Original",
-            y.view(-1, c, h, w)[:, bands, :, :],
+            y.view(-1, c, h, w)[:4, bands, :, :],
             global_step=epoch,
             dataformats="NCHW",
         )
 
         writer.add_images(
             "Reconstruction/LR",
-            y_hat.view(-1, c, h, w)[:, bands, :, :],
+            y_hat.view(-1, c, h, w)[:4, bands, :, :],
             global_step=epoch,
             dataformats="NCHW",
         )
@@ -162,21 +161,21 @@ def train(
         conditional_gen = model.conditional_generation(y)
         writer.add_images(
             "Conditional Generation/LR_Original",
-            y.view(-1, c, h, w)[:, bands, :, :],
+            y.view(-1, c, h, w)[:4, bands, :, :],
             global_step=epoch,
             dataformats="NCHW",
         )
 
         writer.add_images(
             "Conditional Generation/HR",
-            conditional_gen.view(-1, c, h * 2, w * 2)[:, bands, :, :],
+            conditional_gen.view(-1, c, h * 2, w * 2)[:4, bands, :, :],
             global_step=epoch,
             dataformats="NCHW",
         )
 
         writer.add_images(
             "Conditional Generation/HR_Original",
-            x.view(-1, c, h * 2, w * 2)[:, bands, :, :],
+            x.view(-1, c, h * 2, w * 2)[:4, bands, :, :],
             global_step=epoch,
             dataformats="NCHW",
         )
@@ -184,7 +183,7 @@ def train(
         writer.add_images(
             "Conditional Generation/HR_Interpolation",
             F.interpolate(
-                y.view(-1, c, h, w)[:, bands, :, :], scale_factor=2, mode="bicubic"
+                y.view(-1, c, h, w)[:4, bands, :, :], scale_factor=2, mode="bicubic"
             ),
             global_step=epoch,
             dataformats="NCHW",
@@ -192,14 +191,14 @@ def train(
 
         writer.add_images(
             "Reconstruction/HR_Original",
-            x.view(-1, c, h * 2, w * 2)[:, bands, :, :],
+            x.view(-1, c, h * 2, w * 2)[:4, bands, :, :],
             global_step=epoch,
             dataformats="NCHW",
         )
 
         writer.add_images(
             "Reconstruction/HR",
-            x_hat.view(-1, c, h * 2, w * 2)[:, bands, :, :],
+            x_hat.view(-1, c, h * 2, w * 2)[:4, bands, :, :],
             global_step=epoch,
             dataformats="NCHW",
         )
@@ -270,7 +269,7 @@ def main(args):
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model.to(device)
-    optimizer = torch.optim.Adam(model.parameters(), lr=5e-4)
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
     gamma = torch.tensor([1.0]).to(device)
     gamma2 = torch.tensor([1.0]).to(device)
     gamma.requires_grad = True
@@ -351,5 +350,7 @@ if __name__ == "__main__":
     print("==========================")
     print("Initializing training with the following arguments:")
     print(arguments)
+    print("--------------------------")
+    print("Device:", "cuda" if torch.cuda.is_available() else "cpu")
     print("==========================")
     main(args=arguments)


### PR DESCRIPTION
Introduce functionality to compare SRVAE super resolution performance against a bicubic baseline. 

This also includes the removal of image normalization, adjustments to the training process, and enhancements to TensorBoard logging. 

Additionally, implement pre-commit hooks for code formatting and linting to maintain code quality.

Fixes #8, #11