### PR TITLE
Resume training at epoch

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -17,5 +17,5 @@ source activate vae-rs
 
 export SCRATCH="/scratch/disc/e.bardet/"
 
-python train.py --patch_size 64 --batch_size 2 --pre_epochs 0 --model_ckpt "pre_best_model_3846651.pth"
+python train.py --patch_size 64 --batch_size 2 --pre_epochs 0
 

--- a/train.py
+++ b/train.py
@@ -294,13 +294,14 @@ def main(args):
     if args.model_ckpt:
         print("Loading model from checkpoint...")
         save_dict = torch.load(args.model_ckpt)
-        start_epoch = save_dict["epoch"]
+        start_epoch = save_dict["epoch"] + 1
         model.load_state_dict(save_dict["model_state_dict"])
         print("Model loaded successfully.")
         print("Loading optimizer state...")
         gamma = save_dict["gamma"]
         gamma2 = save_dict["gamma2"]
         optimizer = torch.optim.Adam(model.parameters(), lr=5e-4)
+        optimizer.add_param_group({"params": [gamma, gamma2]})
         optimizer.load_state_dict(save_dict["optimizer_state_dict"])
         print("Optimizer state loaded successfully.")
     else:

--- a/train.py
+++ b/train.py
@@ -315,6 +315,8 @@ def main(args):
     for param_group in optimizer.param_groups:
         param_group["lr"] = 5e-4
 
+    model.compile(mode="reduce-overhead")
+
     train(
         device,
         model,

--- a/train.py
+++ b/train.py
@@ -315,8 +315,6 @@ def main(args):
     for param_group in optimizer.param_groups:
         param_group["lr"] = 5e-4
 
-    model.compile(mode="reduce-overhead")
-
     train(
         device,
         model,


### PR DESCRIPTION
Enable resuming training from a specified epoch by adding a `start_epoch` parameter. This allows the model and optimizer states to be loaded from a checkpoint, facilitating continued training without starting over.

Fixes #22